### PR TITLE
Add support for Apple Silicon (darwin-arm64)

### DIFF
--- a/.github/workflows/publish-glast.yml
+++ b/.github/workflows/publish-glast.yml
@@ -16,7 +16,7 @@ jobs:
         name: "Run test suite"
         strategy:
             matrix:
-                os: [windows-latest, macos-latest, ubuntu-latest]
+                os: [windows-latest, macos-13, macos-latest, ubuntu-latest]
         runs-on: ${{ matrix.os }}
         timeout-minutes: 10
 

--- a/.github/workflows/publish-glsl-lsp.yml
+++ b/.github/workflows/publish-glsl-lsp.yml
@@ -16,7 +16,7 @@ jobs:
         name: "Run test suite"
         strategy:
             matrix:
-                os: [windows-latest, macos-latest, ubuntu-latest]
+                os: [windows-latest, macos-13, macos-latest, ubuntu-latest]
         runs-on: ${{ matrix.os }}
         timeout-minutes: 10
 
@@ -36,12 +36,14 @@ jobs:
         strategy:
             matrix:
                 include:
-                  - os: windows-latest
-                    target: x86_64-pc-windows-msvc
-                  - os: ubuntu-latest
-                    target: x86_64-unknown-linux-gnu
-                  - os: macos-latest
-                    target: x86_64-apple-darwin
+                    - os: windows-latest
+                      target: x86_64-pc-windows-msvc
+                    - os: ubuntu-latest
+                      target: x86_64-unknown-linux-gnu
+                    - os: macos-13
+                      target: x86_64-apple-darwin
+                    - os: macos-latest
+                      target: aarch64-apple-darwin
         outputs:
             VERSION: ${{ steps.build-script.outputs.VERSION }}
         runs-on: ${{ matrix.os }}
@@ -69,8 +71,8 @@ jobs:
             - name: Upload artifact for later github release
               uses: actions/upload-artifact@v3
               with:
-                name: glsl-lsp-${{ matrix.target }}
-                path: ./publish/glsl-lsp-${{ matrix.target }}-${{ steps.build-script.outputs.VERSION }}.zip
+                  name: glsl-lsp-${{ matrix.target }}
+                  path: ./publish/glsl-lsp-${{ matrix.target }}-${{ steps.build-script.outputs.VERSION }}.zip
 
     gh-release:
         name: "Create github release"
@@ -101,4 +103,5 @@ jobs:
                       ./glsl-lsp-x86_64-pc-windows-msvc/glsl-lsp-x86_64-pc-windows-msvc-${{ needs.build.outputs.VERSION }}.zip
                       ./glsl-lsp-x86_64-unknown-linux-gnu/glsl-lsp-x86_64-unknown-linux-gnu-${{ needs.build.outputs.VERSION }}.zip
                       ./glsl-lsp-x86_64-apple-darwin/glsl-lsp-x86_64-apple-darwin-${{ needs.build.outputs.VERSION }}.zip
+                      ./glsl-lsp-aarch64-apple-darwin/glsl-lsp-aarch64-apple-darwin-${{ needs.build.outputs.VERSION }}.zip
                   fail_on_unmatched_files: true

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -23,9 +23,12 @@ jobs:
                     - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       vsce_target: linux-x64
-                    - os: macos-latest
+                    - os: macos-13
                       target: x86_64-apple-darwin
                       vsce_target: darwin-x64
+                    - os: macos-latest
+                      target: aarch64-apple-darwin
+                      vsce_target: darwin-arm64
         outputs:
             EXT_VERSION: ${{ steps.build-script.outputs.EXT_VERSION }}
         runs-on: ${{ matrix.os }}
@@ -110,4 +113,5 @@ jobs:
                       ./glsl-lsp-win32-x64/glsl-lsp-win32-x64-${{ needs.deploy.outputs.EXT_VERSION }}.vsix
                       ./glsl-lsp-linux-x64/glsl-lsp-linux-x64-${{ needs.deploy.outputs.EXT_VERSION }}.vsix
                       ./glsl-lsp-darwin-x64/glsl-lsp-darwin-x64-${{ needs.deploy.outputs.EXT_VERSION }}.vsix
+                      ./glsl-lsp-darwin-arm64/glsl-lsp-darwin-arm64-${{ needs.deploy.outputs.EXT_VERSION }}.vsix
                   fail_on_unmatched_files: true

--- a/build/Instructions.md
+++ b/build/Instructions.md
@@ -19,6 +19,7 @@ Prerequisites:
 |`x86_64-pc-windows-msvc`|`glsl-lsp.exe`|`win32-x64`|
 |`x86_64-unknown-linux-gnu`|`glsl-lsp`|`linux-x64`|
 |`x86_64-apple-darwin`|`glsl-lsp`|`darwin-x64`|
+|`aarch64-apple-darwin`|`glsl-lsp`|`darwin-arm64`|
 
 `$VERSION` is the current version of the extension found in the client [package manifest](/client/package.json).
 

--- a/build/release-glsl-lsp.ps1
+++ b/build/release-glsl-lsp.ps1
@@ -1,6 +1,6 @@
 ﻿param (
 	[string]
-	[ValidateSet("x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin")]
+	[ValidateSet("x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin")]
 	$Target
 )
 
@@ -41,6 +41,10 @@ switch ($Target) {
 			-Destination (Join-Path $script:DEST "glsl-lsp") -Verbose
 	}
 	"x86_64-apple-darwin" {
+		Copy-Item -Path (Join-Path $script:ROOT "server" "target" $Target "release" "glsl-lsp") `
+			-Destination (Join-Path $script:DEST "glsl-lsp") -Verbose 
+	}
+	"aarch64-apple-darwin" {
 		Copy-Item -Path (Join-Path $script:ROOT "server" "target" $Target "release" "glsl-lsp") `
 			-Destination (Join-Path $script:DEST "glsl-lsp") -Verbose 
 	}

--- a/build/release-vscode.ps1
+++ b/build/release-vscode.ps1
@@ -1,6 +1,6 @@
 ﻿param (
 	[string]
-	[ValidateSet("x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin")]
+	[ValidateSet("x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin")]
 	$Target
 )
 
@@ -54,6 +54,7 @@ switch ($Target) {
 	"x86_64-pc-windows-msvc" { $serverPath = "glsl-lsp.exe" }
 	"x86_64-unknown-linux-gnu" { $serverPath = "glsl-lsp" }
 	"x86_64-apple-darwin" { $serverPath = "glsl-lsp" }
+	"aarch64-apple-darwin" { $serverPath = "glsl-lsp" }
 }
 $script = Get-Content -Path (Join-Path $script:OUT_DIR "src" "main.ts")
 $script = $script -replace "\`${GLSL_SERVER_PATH}", $serverPath


### PR DESCRIPTION
This PR updates the build scripts to add a target for macOS on Apple Silicon. It also updates the Github Actions for this new target.

I tested the Github Actions by commenting out the steps which publish to crates.io and the VS Code Extension Marketplace, and they completed successfully. As the `macos-latest` OS version now runs on arm64 hardware, the `x86_64-apple-darwin` target was not building successfully, so I explicitly specified `macos-13` for that target, as that is the last OS version supported by Github Actions on `x86_64` hardware.

Fixes #23 